### PR TITLE
lighter docker image for the obpeans-ruby

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,13 @@
+.ci
+.dockerignore
+.editorconfig
+.git
+.gitignore
+.gitmodules
+docker-compose*.yml
 Dockerfile
+Makefile
+README.md
 tests
 bats
+target

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
-FROM ruby:2.6
+FROM ruby:2.6-alpine
 
 WORKDIR /app
+
+## Dependencies for nokogiri and pg
+RUN apk update && \
+    apk --no-cache add build-base && \
+    apk --no-cache add postgresql-dev && \
+    rm -rf /var/cache/apk/*
 
 COPY Gemfile Gemfile.lock /app/
 ENV BUNDLER_VERSION 2.0.1

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'lograge'
 gem 'pg'
 gem 'puma'
 gem 'rails', '~> 5.2'
+gem 'tzinfo-data'
 
 group :development do
   gem 'bootsnap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,8 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2019.3)
+      tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
@@ -166,6 +168,7 @@ DEPENDENCIES
   pg
   puma
   rails (~> 5.2)
+  tzinfo-data
 
 BUNDLED WITH
    2.0.2

--- a/bin/boot
+++ b/bin/boot
@@ -1,3 +1,4 @@
-#!/bin/bash -ex
+#!/usr/bin/env sh
+set -ex
 bin/setup
 bundle exec foreman start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://opbeans-ruby:5000/"]
+      test: ["CMD", "wget", "-q", "--server-response", "http://opbeans-ruby:5000/"]
       interval: 10s
       retries: 10
 
@@ -138,7 +138,7 @@ services:
     depends_on:
       opbeans-ruby:
         condition: service_healthy
-        
+
 volumes:
   esdata:
     driver: local


### PR DESCRIPTION
## Highlights
- From `1gb` docker image to `370mb`.
- Use the alpine version and the packages required to install nokogiri and pg

## Package dependencies
- https://github.com/ged/ruby-pg#requirements
- https://github.com/sparklemotion/nokogiri#requirements