### PR TITLE
fix: bump elastic-apm to 3.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ GEM
     crass (1.0.5)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    elastic-apm (2.9.1)
+    elastic-apm (3.1.0)
       concurrent-ruby (~> 1.0)
       http (>= 3.0)
     erubi (1.8.0)


### PR DESCRIPTION
## What does this PR do?

It bumps the elastic-apm to 3.1.0

## Why is it important?

Currently, tests are failing because the code uses a method that it is not in the elastic-apm gem version set in the Gemfile.lock.

## Related issues
Closes #21 
