### PR TITLE
fix: trim left whitespaces on log records

### DIFF
--- a/bin/boot
+++ b/bin/boot
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 set -exo pipefail
 bin/setup
-bundle exec foreman start 2>&1 | cut -d '|' -f 2
+bundle exec foreman start 2>&1 | cut -d '|' -f 2 | sed -e 's/^[[:space:]]*//'


### PR DESCRIPTION
## What does this PR do?

It removes all whitespaces at the left of each log line.

## Why is it important?

The lines that start with whitespace used to be part of a multiline log entry, so those lines match with a no JSON pattern and are evaluated twice. 
