### PR TITLE
feat: bump Agent Ruby version to 3.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ GEM
     crass (1.0.5)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    elastic-apm (3.1.0)
+    elastic-apm (3.3.0)
       concurrent-ruby (~> 1.0)
       http (>= 3.0)
     erubi (1.8.0)


### PR DESCRIPTION
bump Agent Ruby version to 3.3.0

closes #37 