### PR TITLE
feat: bump Agent Ruby version to 3.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ GEM
     crass (1.0.5)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    elastic-apm (3.1.0)
+    elastic-apm (3.2.0)
       concurrent-ruby (~> 1.0)
       http (>= 3.0)
     erubi (1.8.0)


### PR DESCRIPTION
bump Agent Ruby version to 3.2.0, this is an intermediate version that we do not release opbeans, so we have to merge it before 3.3.0 bump, then release the tag v3.2.0, finally, we will bump to v3.3.0 and release a new tag

closes #36 