### PR TITLE
fix: agent version is matching the tag name

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -3,6 +3,9 @@ set -euxo pipefail
 
 AGENT_VERSION="${1?Missing the APM ruby agent version}"
 
+## Normalise the agent version that it's coming from the tag name.
+NEW_AGENT_VERSION=$(echo ${AGENT_VERSION} | sed 's#^v##g')
+
 ## Gather ruby version
 RUBY_VERSION=$(grep '^ruby' Gemfile | sed -E "s/.*[\"'](.+)[\"']/\1/")
 
@@ -18,8 +21,8 @@ docker run --rm -t \
     bundle update elastic-apm"
 
 # Validate whether the agent version matches
-git diff --name-only -S"elastic-apm (${AGENT_VERSION})" | grep Gemfile.lock
+git diff --name-only -S"elastic-apm (${NEW_AGENT_VERSION})" | grep Gemfile.lock
 
 # Commit changes
 git add Gemfile.lock
-git commit -m "fix(package): bump elastic-apm to version ${AGENT_VERSION}"
+git commit -m "fix(package): bump elastic-apm to version ${NEW_AGENT_VERSION}"


### PR DESCRIPTION
The release process for the opbeans is coming from the agent itself, so any time a tag release is created then this particular script is executed. Therefore the name of the tag and the agent version in the Gemfile differs
only from the very first character `v`.

This is the fix to normalize the version for the agent in the Gemfile.


The [build](https://github.com/elastic/apm-agent-ruby/tree/v3.3.0) failed as there was a diff between the agent version and the gemfile dependency version.\

```
[2019-12-05T08:25:25.545Z] + git diff --name-only '-Selastic-apm (v3.3.0)'
[2019-12-05T08:25:25.545Z] + grep Gemfile.lock
```

## Tests


```bash
$ AGENT_VERSION=v3.3.0
$ NEW_AGENT_VERSION=$(echo ${AGENT_VERSION} | sed 's#^v##g')
$echo $NEW_AGENT_VERSION 
3.3.0

