### PR TITLE
Add debug output when failing the git diff

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -24,7 +24,7 @@ docker run --rm -t \
 git diff --name-only -S"elastic-apm (${NEW_AGENT_VERSION})" | grep Gemfile.lock && found=1 || found=0
 if [ ${found} -eq 0 ] ; then
   echo 'ERROR: Agent version was not updated. See the below diff detail output:'
-  git diff Gemfile.lock
+  git diff --unified=0 Gemfile.lock
   exit 1
 fi
 

--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -21,7 +21,12 @@ docker run --rm -t \
     bundle update elastic-apm"
 
 # Validate whether the agent version matches
-git diff --name-only -S"elastic-apm (${NEW_AGENT_VERSION})" | grep Gemfile.lock
+git diff --name-only -S"elastic-apm (${NEW_AGENT_VERSION})" | grep Gemfile.lock && found=1 || found=0
+if [ ${found} -eq 0 ] ; then
+  echo 'ERROR: Agent version was not updated. See the below diff detail output:'
+  git diff Gemfile.lock
+  exit 1
+fi
 
 # Commit changes
 git add Gemfile.lock


### PR DESCRIPTION
This script is called from the release tags for the apm-agent-ruby but it did not provide enough details when there was a failure.

Not sure if the gem dependency takes a bit to be available in the Gem central repo, but let's add this particular debug output to track whether there are any errors in the validation.


## Tests

- If the  agent release was released

```bash
$ .ci/bump-version.sh 3.4.0
+ git diff --name-only '-Selastic-apm (3.4.0)'
+ grep Gemfile.lock
Gemfile.lock
+ found=1
+ '[' 1 -eq 0 ']'
...
```

- If the agent release was not released yet

```bash
$ .ci/bump-version.sh 3.5.0
...
+ git diff --name-only '-Selastic-apm (3.5.0)'
+ grep Gemfile.lock
+ found=0
+ '[' 0 -eq 0 ']'
+ echo 'ERROR: Agent version was not updated. See the below diff detail output'
ERROR: Agent version was not updated. See the below diff detail output
+ git diff --unified=0 Gemfile.lock
diff --git a/Gemfile.lock b/Gemfile.lock
index b1cd5fb..ec3df45 100644
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,2 +45,2 @@ GEM
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
@@ -55 +55 @@ GEM
-    elastic-apm (3.3.0)
+    elastic-apm (3.4.0)
...
+ exit 1
```