### PR TITLE
Bump ruby 2.6.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-alpine
+FROM ruby:2.6.6-alpine
 
 WORKDIR /app
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.6.5'
+ruby '2.6.6'
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     foreman (0.87.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    http (4.3.0)
+    http (4.4.1)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
@@ -151,7 +151,7 @@ GEM
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.6)
+    unf_ext (0.0.7.7)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -173,7 +173,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.6.5p114
+   ruby 2.6.6p146
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
Otherwise:


```
[2020-04-02T05:00:30.847Z] Step 7/10 : RUN bundle install --jobs 20 --retry 5
[2020-04-02T05:00:30.847Z]  ---> Running in 3cd376a3675d
[2020-04-02T05:00:32.233Z] Your Ruby version is 2.6.6, but your Gemfile specified 2.6.5
[2020-04-02T05:00:32.233Z] The command '/bin/sh -c bundle install --jobs 20 --retry 5' returned a non-zero code: 18

```