### PR TITLE
docker: add labels metadata

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -30,6 +30,9 @@ if [ ${found} -eq 0 ] ; then
   exit 1
 fi
 
+## Bump agent version in the Dockerfile
+sed -ibck "s#\(org.label-schema.version=\)\(.*\)#\1\"${NEW_AGENT_VERSION}\"#g" Dockerfile
+
 # Commit changes
-git add Gemfile.lock
+git add Gemfile.lock Dockerfile
 git commit -m "fix(package): bump elastic-apm to version ${NEW_AGENT_VERSION}"

--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -31,7 +31,7 @@ if [ ${found} -eq 0 ] ; then
 fi
 
 ## Bump agent version in the Dockerfile
-sed -ibck "s#\(org.label-schema.version=\)\(.*\)#\1\"${NEW_AGENT_VERSION}\"#g" Dockerfile
+sed -ibck "s#\(org.label-schema.version=\)\(\".*\"\)\(.*\)#\1\"${NEW_AGENT_VERSION}\"\3#g" Dockerfile
 
 # Commit changes
 git add Gemfile.lock Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,13 @@ COPY . /app
 
 COPY --from=opbeans/opbeans-frontend:latest /app/build /app/frontend/build
 
+LABEL \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.vendor="Elastic" \
+    org.label-schema.name="opbeans-ruby" \
+    org.label-schema.version="3.8.0" \
+    org.label-schema.url="https://hub.docker.com/r/opbeans/opbeans-ruby" \
+    org.label-schema.vcs-url="https://github.com/elastic/opbeans-ruby" \
+    org.label-schema.license="MIT"
+
 CMD ["bin/boot"]


### PR DESCRIPTION
Added some labels to easily identify what's the agent version that the opbeans is consuming, in addition to some labels that are generated for some other Elastic docker images.

### Tests

```bash
IMAGE=docker.elastic.co/observability-ci/opbeans-ruby:fd8ecba56d6d60af8daeb3cc4a7c1726272bd53f
$ docker pull ${IMAGE}
$ docker inspect ${IMAGE} | jq -r '.[0].Config.Labels'
{
  "org.label-schema.license": "MIT",
  "org.label-schema.name": "opbeans-ruby",
  "org.label-schema.schema-version": "1.0",
  "org.label-schema.url": "https://hub.docker.com/r/opbeans/opbeans-ruby",
  "org.label-schema.vcs-url": "https://github.com/elastic/opbeans-ruby",
  "org.label-schema.vendor": "Elastic",
  "org.label-schema.version": "3.8.0"
}
```