### PR TITLE
[dependabot] enable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+---
+version: 2
+updates:
+  # Enable version updates for ruby
+  - package-ecosystem: "bundler"
+    # Look for `Gemfile` file in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "elastic/apm-agent-ruby"
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "elastic/apm-agent-ruby"


### PR DESCRIPTION
### What

Enable dependabot to monitor any of the dependencies and notify the apm-agent-ruby team


### Why

Bump versions when required and monitor the ones related to any security issues