### PR TITLE
fix(package): bump elastic-apm to version 4.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ LABEL \
     org.label-schema.schema-version="1.0" \
     org.label-schema.vendor="Elastic" \
     org.label-schema.name="opbeans-ruby" \
-    org.label-schema.version="4.2.0" \
+    org.label-schema.version="4.5.0" \
     org.label-schema.url="https://hub.docker.com/r/opbeans/opbeans-ruby" \
     org.label-schema.vcs-url="https://github.com/elastic/opbeans-ruby" \
     org.label-schema.license="MIT"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
     bootsnap (1.9.1)
       msgpack (~> 1.0)
     builder (3.2.4)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     crass (1.0.6)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -73,7 +73,7 @@ GEM
       concurrent-ruby (~> 1.0)
       http (>= 3.0)
     erubi (1.10.0)
-    ffi (1.15.4)
+    ffi (1.15.5)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -117,7 +117,7 @@ GEM
     nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
     pg (1.2.3)
-    public_suffix (4.0.6)
+    public_suffix (4.0.7)
     puma (5.5.2)
       nio4r (~> 2.0)
     racc (1.5.2)
@@ -170,7 +170,7 @@ GEM
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.8)
+    unf_ext (0.0.8.1)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -197,4 +197,4 @@ RUBY VERSION
    ruby 2.7.3p183
 
 BUNDLED WITH
-   2.2.22
+   2.3.12

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,4 +197,4 @@ RUBY VERSION
    ruby 2.7.3p183
 
 BUNDLED WITH
-   2.3.12
+   2.2.22


### PR DESCRIPTION
Update lock and docker metadata.

Then I'll create the tag release

Dependabot has been bumping the versions but missed to update the Gemfile.lock and docker images as per described in https://github.com/elastic/opbeans-ruby/blob/main/.ci/bump-version.sh

The automation relies on the git tags for the apm-agent-ruby, which were disabled for a period of time, but dependabot seems to be doing its job