### PR TITLE
Add opencontainers labels and improve bump version script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,13 @@ LABEL \
     org.label-schema.version="4.5.0" \
     org.label-schema.url="https://hub.docker.com/r/opbeans/opbeans-ruby" \
     org.label-schema.vcs-url="https://github.com/elastic/opbeans-ruby" \
-    org.label-schema.license="MIT"
+    org.label-schema.license="MIT" \
+    org.opencontainers.image.vendor="Elastic" \
+    org.opencontainers.image.title="opbeans-ruby" \
+    org.opencontainers.image.version="4.5.0" \
+    org.opencontainers.image.url="https://hub.docker.com/r/opbeans/opbeans-ruby" \
+    org.opencontainers.image.source="https://github.com/elastic/opbeans-ruby" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.base.name="ruby:2.7.3-alpine"
 
 CMD ["bin/boot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ruby:2.7.3-alpine
+ARG RUBY_IMAGE="ruby:2.7.3-alpine"
+FROM ${RUBY_IMAGE}
+ARG RUBY_IMAGE
 
 WORKDIR /app
 
@@ -31,6 +33,6 @@ LABEL \
     org.opencontainers.image.url="https://hub.docker.com/r/opbeans/opbeans-ruby" \
     org.opencontainers.image.source="https://github.com/elastic/opbeans-ruby" \
     org.opencontainers.image.licenses="MIT" \
-    org.opencontainers.image.base.name="ruby:2.7.3-alpine"
+    org.opencontainers.image.base.name="${RUBY_IMAGE}"
 
 CMD ["bin/boot"]

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ git_source(:github) do |repo_name|
 end
 
 gem 'sprockets'
-gem 'elastic-apm'
+gem 'elastic-apm', '4.5.0'
 gem 'foreman'
 gem 'http'
 gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,9 +109,13 @@ GEM
     marcel (1.0.1)
     method_source (1.0.0)
     mini_mime (1.1.1)
+    mini_portile2 (2.6.1)
     minitest (5.14.4)
     msgpack (1.4.2)
     nio4r (2.5.8)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
     nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
@@ -177,12 +181,13 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  aarch64-linux
   x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
   bootsnap
-  elastic-apm
+  elastic-apm (= 4.5.0)
   foreman
   http
   listen


### PR DESCRIPTION
* Add opencontainers labels as describe in https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
* Define elastic-apm version explicitly in Gemfile
* Update bump-version script according previous changes

Signed-off-by: Adrien Mannocci <adrien.mannocci@elastic.co>