### PR TITLE
Fix bundle update script

### DIFF
--- a/.ci/bump-opbeans-ruby.yml
+++ b/.ci/bump-opbeans-ruby.yml
@@ -85,6 +85,7 @@ targets:
       - gemfile
     name: Bump elastic-apm
     sourceid: elastic-apm-agent-ruby
+    disablesourceinput: true
     scmid: githubConfig
     kind: shell
     spec:


### PR DESCRIPTION
## Details

The workflow https://github.com/elastic/opbeans-ruby/actions/runs/4903379466 is failing because the last updatecli target `gem` is executing the command `bundle update elastic-apm d.d.d` (where `d.d.d` is the found version) 
and it fails because the version `d.d.d` does not exist.

`disablesourceinput: true` should disable appending the version to the command and only execute `bundle update elastic-apm` 