### PR TITLE
Add updatecli condition

### DIFF
--- a/.ci/bump-opbeans-ruby.yml
+++ b/.ci/bump-opbeans-ruby.yml
@@ -46,6 +46,16 @@ sources:
     transformers:
       - trimprefix: "v"
 
+conditions:
+  checkIfVersionDiffers:
+    name: Check if installed version differs
+    kind: shell
+    sourceid: elastic-apm-agent-ruby
+    spec:
+      command: bash .ci/scripts/test-version.sh
+      environments:
+        - name: PATH
+
 targets:
   dockerfile-label-schema:
     name: Set org.label-schema.version in Dockerfile

--- a/.ci/bump-opbeans-ruby.yml
+++ b/.ci/bump-opbeans-ruby.yml
@@ -53,8 +53,6 @@ conditions:
     sourceid: elastic-apm-agent-ruby
     spec:
       command: .ci/scripts/test-version.sh
-      environments:
-        - name: PATH
 
 targets:
   dockerfile-label-schema:

--- a/.ci/bump-opbeans-ruby.yml
+++ b/.ci/bump-opbeans-ruby.yml
@@ -52,7 +52,7 @@ conditions:
     kind: shell
     sourceid: elastic-apm-agent-ruby
     spec:
-      command: bash .ci/scripts/test-version.sh
+      command: .ci/scripts/test-version.sh
       environments:
         - name: PATH
 

--- a/.ci/scripts/test-version.sh
+++ b/.ci/scripts/test-version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# This script checks the difference of the input and the version of elastic-apm in Gemfile.lock
+# If the input and the version in the Gemfile.lock file are equal the script returns a non zero exit code.
+# If the input and the version in the Gemfile.lock file differ the script return a 0 exit code.
+#
+# This is used for an updatecli condition to determine if the pipeline should continue or not.
+
+set -euo pipefail
+
+version=$(grep elastic-apm Gemfile.lock | head -1 | awk -F'[()]' '{ print $2 }')
+
+test "$version" != "$1"


### PR DESCRIPTION
## Details

The workflow https://github.com/elastic/opbeans-ruby/actions/runs/4968635143 is failing with "nothing to commit"

Adding a `condition` should stop the updatecli pipeline to continue if the given version is already installed.