### PR TITLE
fix: install the latest compatible bundler version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN apk update && \
     rm -rf /var/cache/apk/*
 
 COPY Gemfile Gemfile.lock /app/
-ENV BUNDLER_VERSION 2.2.15
-RUN gem install bundler
+ENV BUNDLER_VERSION 2.4.22
+RUN gem install bundler -v ${BUNDLER_VERSION}
 RUN bundle install --jobs 20 --retry 5
 
 COPY . /app


### PR DESCRIPTION
## What is the change being made?

* Install the latest bundler version compatible with Ruby 2.7.3.

## Why is the change being made?

* The build fails because bundler developers drop support of Ruby 2.6 and 2.7 in the 2.5.x version of bundler.
